### PR TITLE
Update to conflict with breaking typeguard changes

### DIFF
--- a/custom_components/victorsmartkill/manifest.json
+++ b/custom_components/victorsmartkill/manifest.json
@@ -10,6 +10,7 @@
     "@toreamun"
   ],
   "requirements": [
+    "typeguard<3.0.0",
     "victor-smart-kill==1.1.1"
   ],
   "iot_class": "cloud_polling"


### PR DESCRIPTION
As noted in https://github.com/agronholm/typeguard/blob/master/docs/versionhistory.rst and #38 installing `victorsmartkill` module encounters an error.  Simply blocking the behaviour of "blindly install the latest" of `typeguard` causes @toreamun's module to install and become active, immediately appearing on the "Integrations" page in HomeAssistant.

Seems to resolve #38 