### PR TITLE
update TEMP_CELSIUS to UnitOfTemperature.CELSIUS

### DIFF
--- a/custom_components/victorsmartkill/sensor.py
+++ b/custom_components/victorsmartkill/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     ATTR_LONGITUDE,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    TEMP_CELSIUS,
+    UnitOfTemperature,
 )
 from homeassistant.helpers.entity import Entity, EntityCategory
 from homeassistant.helpers.typing import HomeAssistantType, StateType
@@ -148,7 +148,7 @@ def _create_trap_sensors(coordinator, trap: victor.Trap):
                     ATTR_LONGITUDE,
                 ],
                 value_func=lambda t: t.trapstatistics.temperature_celcius,
-                native_unit_of_measurement=TEMP_CELSIUS,
+                native_unit_of_measurement=UnitOfTemperature.CELSIUS,
                 device_class=SensorDeviceClass.TEMPERATURE,
                 entity_registry_enabled_default=trap.trapstatistics.temperature
                 is not None,

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Victor Smart-Kill",
-  "homeassistant": "2022.8.0b0",
+  "homeassistant": "2023.1.7",
   "render_readme": true
 }


### PR DESCRIPTION
On [Oct 26, 2022](https://github.com/home-assistant/core/commit/842cb18d3948709fcb1579535d38cfc28356dfda#diff-07e20eb7c6560330f9774eb23343f5dd3002106bb8b6523ccb18d95857990d77), homeassistant migrated temperature units to an enum UnitOfTemperature and depreated TEMP_CELSIUS. The removal date for these constants is Jan of 2025. Using the new enum will require a homeassistant version of 2022.11.0 or greater while the current minimum version is 2022.8.0b0. I have further raised the min version to 2023.1.7 but this is just arbitrary and I can update the PR if maximum compatibility is required.

Closes #41 