### PR TITLE
update action versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,14 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: [ "master" ]
+    branches:
+      - master
   pull_request:
-    branches: [ "master" ]
+    branches:
+      - master
   schedule:
-    - cron: "52 9 * * 5"
+    - cron: 52 9 * * 5
 
 jobs:
   analyze:
@@ -16,26 +18,22 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [ python ]
-
+        language:
+          - python
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
-          languages: ${{ matrix.language }}
+          languages: '${{ matrix.language }}'
           queries: +security-and-quality
-
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
-
+        uses: github/codeql-action/autobuild@v3
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
-          category: "/language:${{ matrix.language }}"
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -2,20 +2,18 @@ name: Cron actions
 
 on:
   schedule:
-    - cron:  '0 0 * * *'
+    - cron: 0 0 * * *
 
 jobs:
   validate:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     name: Validate
     steps:
-        - uses: "actions/checkout@v2"
-
-        - name: HACS validation
-          uses: "hacs/action@main"
-          with:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            category: "integration"
-
-        - name: Hassfest validation
-          uses: "home-assistant/actions/hassfest@master"
+      - uses: actions/checkout@v4
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          category: integration
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,11 @@ name: Publish
 
 on:
   release:
-    types: [published]
+    types:
+      - published
   push:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
   release_zip_file:
@@ -12,28 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v4
       - name: Upload zip to action
-        uses: actions/upload-artifact@v2
-        if: ${{ github.event_name == 'push' }}
+        uses: actions/upload-artifact@v4
+        if: '${{ github.event_name == "push" }}'
         with:
           name: victorsmartkill
-          path: ${{ github.workspace }}/custom_components/victorsmartkill
-
-      # Pack the victorsmartkill directory as a zip and upload to the release
+          path: '${{ github.workspace }}/custom_components/victorsmartkill'
       - name: ZIP victorsmartkill directory
-        if: ${{ github.event_name == 'release' }}
+        if: '${{ github.event_name == "release" }}'
         run: |
           cd ${{ github.workspace }}/custom_components/victorsmartkill
           zip victorsmartkill.zip -r ./
-
       - name: Upload zip to release
-        uses: svenstaro/upload-release-action@v1-release
-        if: ${{ github.event_name == 'release' }}
+        uses: svenstaro/upload-release-action@v2
+        if: '${{ github.event_name == "release" }}'
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ github.workspace }}/custom_components/victorsmartkill/victorsmartkill.zip
+          repo_token: '${{ secrets.GITHUB_TOKEN }}'
+          file: '${{ github.workspace }}/custom_components/victorsmartkill/victorsmartkill.zip'
           asset_name: victorsmartkill.zip
-          tag: ${{ github.ref }}
+          tag: '${{ github.ref }}'
           overwrite: true

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,7 +1,7 @@
 name: Pull actions
 
 on:
-  pull_request: null
+  pull_request:
 
 jobs:
   validate:
@@ -9,21 +9,27 @@ jobs:
     name: Validate
     steps:
       - uses: actions/checkout@v4
+
       - name: HACS validation
         uses: hacs/action@main
         with:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CATEGORY: integration
+
       - name: Hassfest validation
         uses: home-assistant/actions/hassfest@master
+
   style:
     runs-on: ubuntu-latest
     name: Check style formatting
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-          cache: "pip"
+          python-version: 3.12
+          cache: pip
+
       - run: pip install black
+
       - run: black .

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,31 +1,29 @@
 name: Pull actions
 
 on:
-  pull_request:
+  pull_request: null
 
 jobs:
   validate:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     name: Validate
     steps:
-        - uses: "actions/checkout@v2"
-
-        - name: HACS validation
-          uses: "hacs/action@main"
-          with:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            CATEGORY: "integration"
-
-        - name: Hassfest validation
-          uses: "home-assistant/actions/hassfest@master"
-
+      - uses: actions/checkout@v4
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CATEGORY: integration
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master
   style:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     name: Check style formatting
     steps:
-        - uses: "actions/checkout@v2"
-        - uses: "actions/setup-python@v1"
-          with:
-            python-version: "3.x"
-        - run: python3 -m pip install black
-        - run: black .
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: "pip"
+      - run: pip install black
+      - run: black .

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,24 +11,25 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate
     steps:
-        - uses: "actions/checkout@v2"
+      - uses: actions/checkout@v4
 
-        - name: HACS validation
-          uses: "hacs/action@main"
-          with:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            CATEGORY: "integration"
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CATEGORY: integration
 
-        - name: Hassfest validation
-          uses: "home-assistant/actions/hassfest@master"
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master
 
   style:
     runs-on: "ubuntu-latest"
     name: Check style formatting
     steps:
-        - uses: "actions/checkout@v2"
-        - uses: "actions/setup-python@v1"
-          with:
-            python-version: "3.x"
-        - run: python3 -m pip install black
-        - run: black .
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+      - run: pip install black
+      - run: black .

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   validate:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     name: Validate
     steps:
       - uses: actions/checkout@v4
@@ -23,13 +23,16 @@ jobs:
         uses: home-assistant/actions/hassfest@master
 
   style:
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     name: Check style formatting
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-          cache: "pip"
+          python-version: 3.12
+          cache: pip
+
       - run: pip install black
+
       - run: black .


### PR DESCRIPTION
I updated the versions of actions used in workflows as some of them were quite old and used some NodeJS versions are going to be deprecated soon.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
Spring 2024 is the target window to transfer to node 20, although there is no finalized date.