### PR TITLE
Switch from old typing alias to current core types

### DIFF
--- a/custom_components/victorsmartkill/__init__.py
+++ b/custom_components/victorsmartkill/__init__.py
@@ -1,4 +1,5 @@
 """Custom integration to integrate victorsmartkill with Home Assistant."""
+
 from __future__ import annotations
 
 import dataclasses as dc
@@ -13,9 +14,8 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import CALLBACK_TYPE, Config, callback
+from homeassistant.core import CALLBACK_TYPE, Config, callback, Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers.typing import EventType, HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 import victor_smart_kill as victor
 
@@ -39,13 +39,13 @@ class IntegrationContext:
     unsubscribe_list: list[CALLBACK_TYPE] = dc.field(default_factory=list)
 
 
-async def async_setup(hass: HomeAssistantType, config: Config) -> bool:
+async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up this integration using YAML is not supported."""
     # pylint: disable=unused-argument
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
     _LOGGER.debug("async_setup_entry %s.", entry.title)
 
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     return True
 
 
-async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Handle removal of an entry."""
     _LOGGER.debug("async_unload_entry %s.", entry.title)
 
@@ -90,7 +90,7 @@ class VictorSmartKillDataUpdateCoordinator(DataUpdateCoordinator[list[victor.Tra
 
     def __init__(
         self,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         logger: logging.Logger,
         update_interval: dt.timedelta,
         username: str,
@@ -194,7 +194,7 @@ class VictorSmartKillDataUpdateCoordinator(DataUpdateCoordinator[list[victor.Tra
 
 
 async def _async_initialize_coordinator(
-    hass: HomeAssistantType, entry: ConfigEntry
+    hass: HomeAssistant, entry: ConfigEntry
 ) -> VictorSmartKillDataUpdateCoordinator:
     username = entry.data.get(CONF_USERNAME)
     password = entry.data.get(CONF_PASSWORD)
@@ -225,14 +225,12 @@ async def _async_initialize_coordinator(
 
 
 @callback
-async def _async_config_entry_changed(hass: HomeAssistantType, entry: ConfigEntry):
+async def _async_config_entry_changed(hass: HomeAssistant, entry: ConfigEntry):
     _LOGGER.info("Config entry has change. Reload integration.")
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-def _setup_reload(
-    hass: HomeAssistantType, entry: ConfigEntry, context: IntegrationContext
-):
+def _setup_reload(hass: HomeAssistant, entry: ConfigEntry, context: IntegrationContext):
     """Set up listeners of reload triggers."""
     # Listen for config entry changes and reload when changed.
     context.unsubscribe_list.append(
@@ -240,7 +238,7 @@ def _setup_reload(
     )
 
     @callback
-    async def async_trap_list_changed(event: EventType):
+    async def async_trap_list_changed(event: Event):
         _LOGGER.info("Trap list hast changed (%s). Reload integration.", event.data)
         await hass.config_entries.async_reload(entry.entry_id)
 

--- a/custom_components/victorsmartkill/binary_sensor.py
+++ b/custom_components/victorsmartkill/binary_sensor.py
@@ -1,4 +1,5 @@
 """Binary sensor platform for Victor Smart-Kill."""
+
 from __future__ import annotations
 
 import logging
@@ -10,7 +11,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 import victor_smart_kill as victor
 
 from custom_components.victorsmartkill import IntegrationContext
@@ -25,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: Callable[[Iterable[Entity], bool | None], None],
 ) -> None:

--- a/custom_components/victorsmartkill/sensor.py
+++ b/custom_components/victorsmartkill/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for victorsmartkill."""
+
 from __future__ import annotations
 
 import dataclasses as dc
@@ -20,8 +21,9 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfTemperature,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity, EntityCategory
-from homeassistant.helpers.typing import HomeAssistantType, StateType
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 import victor_smart_kill as victor
 
@@ -38,7 +40,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: Callable[[Iterable[Entity], bool | None], None],
 ) -> None:

--- a/get
+++ b/get
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Originally from https://get.hacs.xyz and chaed to fit victorsmartkill integration
+# Originally from https://get.hacs.xyz and changed to fit victorsmartkill integration
 # wget -O - https://raw.githubusercontent.com/toreamun/victorsmartkill-homeassistant/master/get | bash -
 set -e
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Victor Smart-Kill",
-  "homeassistant": "2023.1.7",
+  "homeassistant": "2024.5.0b0",
   "render_readme": true
 }


### PR DESCRIPTION
Se https://developers.home-assistant.io/blog/2024/04/08/deprecated-backports-and-typing-aliases/?_highlight=homeassistant.core.event