### PR TITLE
Use entry.runtime_data

### DIFF
--- a/custom_components/victorsmartkill/binary_sensor.py
+++ b/custom_components/victorsmartkill/binary_sensor.py
@@ -9,12 +9,14 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity import Entity
 from homeassistant.core import HomeAssistant
 import victor_smart_kill as victor
 
-from custom_components.victorsmartkill import IntegrationContext
+from custom_components.victorsmartkill import (
+    IntegrationContext,
+    VictorSmartKillConfigEntry,
+)
 from custom_components.victorsmartkill.const import (
     ATTR_LAST_KILL_DATE,
     DOMAIN,
@@ -27,11 +29,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: VictorSmartKillConfigEntry,
     async_add_entities: Callable[[Iterable[Entity], bool | None], None],
 ) -> None:
     """Set up binary_sensor platform."""
-    context: IntegrationContext = hass.data[DOMAIN][entry.entry_id]
+    context: IntegrationContext = entry.runtime_data
     traps: list[victor.Trap] = context.coordinator.data
 
     entities = []

--- a/custom_components/victorsmartkill/config_flow.py
+++ b/custom_components/victorsmartkill/config_flow.py
@@ -1,9 +1,10 @@
 """Adds config flow for Victor Smart-Kill."""
+
 from __future__ import annotations
 
 import logging
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import ConfigFlow, OptionsFlow
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
@@ -15,6 +16,8 @@ from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 import victor_smart_kill as victor
 import voluptuous as vol  # type: ignore
+
+from custom_components.victorsmartkill import VictorSmartKillConfigEntry
 
 from custom_components.victorsmartkill.const import (  # pylint: disable=unused-import
     DEFAULT_UPDATE_INTERVAL_MINUTES,
@@ -121,7 +124,7 @@ class VictorSmartKillFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+    def async_get_options_flow(config_entry: VictorSmartKillConfigEntry) -> OptionsFlow:
         """Get the options flow for this handler."""
         return VictorSmartKillOptionsFlowHandler(config_entry)
 
@@ -147,13 +150,14 @@ class VictorSmartKillFlowHandler(ConfigFlow, domain=DOMAIN):  # type: ignore
 class VictorSmartKillOptionsFlowHandler(OptionsFlow):
     """Victor Smart-Kill config flow options handler."""
 
-    def __init__(self, config_entry: ConfigEntry):
+    def __init__(self, config_entry: VictorSmartKillConfigEntry):
         """Initialize HACS options flow."""
         self.config_entry = config_entry
         self.options = dict(config_entry.options)
 
     async def async_step_init(
-        self, user_input=None  # pylint: disable=unused-argument
+        self,
+        user_input=None,  # pylint: disable=unused-argument
     ) -> FlowResult:
         """Manage the options."""
         return await self.async_step_user()

--- a/custom_components/victorsmartkill/diagnostics.py
+++ b/custom_components/victorsmartkill/diagnostics.py
@@ -1,14 +1,17 @@
 """Victor Smart-Kill diagnostics."""
+
 from __future__ import annotations
 
 import dataclasses as dc
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from custom_components.victorsmartkill import IntegrationContext
+from custom_components.victorsmartkill import (
+    IntegrationContext,
+    VictorSmartKillConfigEntry,
+)
 from custom_components.victorsmartkill.const import DOMAIN
 
 TO_REDACT_DATA = {
@@ -30,14 +33,14 @@ TO_REDACT_CONFIG = {
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: VictorSmartKillConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     diagnostics = {
         "config_entry": async_redact_data(config_entry.as_dict(), TO_REDACT_CONFIG)
     }
 
-    context: IntegrationContext = hass.data[DOMAIN][config_entry.entry_id]
+    context: IntegrationContext = config_entry.runtime_data
     if context and context.coordinator:
         if context.coordinator.data:
             diagnostics["data"] = async_redact_data(

--- a/custom_components/victorsmartkill/manifest.json
+++ b/custom_components/victorsmartkill/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "victor-smart-kill==1.1.1"
   ],
-  "version": "2023.1.0"
+  "version": "2024.12.0"
 }

--- a/custom_components/victorsmartkill/sensor.py
+++ b/custom_components/victorsmartkill/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_LATITUDE,
@@ -27,7 +26,10 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 import victor_smart_kill as victor
 
-from custom_components.victorsmartkill import IntegrationContext
+from custom_components.victorsmartkill import (
+    IntegrationContext,
+    VictorSmartKillConfigEntry,
+)
 from custom_components.victorsmartkill.const import (
     ATTR_LAST_KILL_DATE,
     ATTR_LAST_REPORT_DATE,
@@ -41,11 +43,11 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: VictorSmartKillConfigEntry,
     async_add_entities: Callable[[Iterable[Entity], bool | None], None],
 ) -> None:
     """Set up sensor platform."""
-    context: IntegrationContext = hass.data[DOMAIN][entry.entry_id]
+    context: IntegrationContext = entry.runtime_data
     traps: list[victor.Trap] = context.coordinator.data
 
     entities = []


### PR DESCRIPTION
Store context in config_entry.runtime_data instead of hass.data[DOMAIN][config_entry.entry_id]

See https://developers.home-assistant.io/blog/2024/04/30/store-runtime-data-inside-config-entry/