### PR TITLE
Improved Linting Workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,25 +8,42 @@ on:
     branches:
       - "master"
 
+permissions:
+    contents: read
+
 jobs:
-  ruff:
-    name: "Ruff"
-    runs-on: "ubuntu-latest"
-    steps:
-        - name: "Checkout the repository"
-          uses: "actions/checkout@v4.1.7"
+    ruff-format:
+        runs-on: ubuntu-latest
 
-        - name: "Set up Python"
-          uses: actions/setup-python@v5.1.0
-          with:
-            python-version: "3.12"
-            cache: "pip"
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-        - name: "Install requirements"
-          run: python3 -m pip install -r requirements.txt
+            - name: Set up Python 3.12
+              uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+              with:
+                  python-version: "3.12"
 
-        - name: "Lint"
-          run: python3 -m ruff check .
+            - name: "Install requirements"
+              run: python3 -m pip install -r requirements.txt
 
-        - name: "Format"
-          run: python3 -m ruff format . --check
+            - name: Run ruff format
+              run: |
+                ruff format --diff --target-version=py312 .
+
+    ruff:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+            - name: Set up Python 3.12
+              uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+              with:
+                  python-version: "3.12"
+
+            - name: "Install requirements"
+              run: python3 -m pip install -r requirements.txt
+            
+            - name: Run ruff
+              run: |
+                ruff check --output-format=github .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,8 @@ jobs:
               uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
               with:
                   python-version: "3.12"
-
+                  cache: "pip"
+    
             - name: "Install requirements"
               run: python3 -m pip install -r requirements.txt
 
@@ -40,6 +41,7 @@ jobs:
               uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
               with:
                   python-version: "3.12"
+                  cache: "pip"
 
             - name: "Install requirements"
               run: python3 -m pip install -r requirements.txt

--- a/custom_components/victorsmartkill/const.py
+++ b/custom_components/victorsmartkill/const.py
@@ -1,4 +1,5 @@
 """Constants for victorsmartkill."""
+
 from __future__ import annotations
 
 # Base component constants

--- a/custom_components/victorsmartkill/entity.py
+++ b/custom_components/victorsmartkill/entity.py
@@ -1,4 +1,5 @@
 """VictorSmartKillEntity class."""
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/custom_components/victorsmartkill/system_health.py
+++ b/custom_components/victorsmartkill/system_health.py
@@ -1,4 +1,5 @@
 """Provide info to system health."""
+
 from __future__ import annotations
 
 from typing import Any


### PR DESCRIPTION
The linting workflow currently only checks formatting if the ruff check passes, because they're two steps within a job.
This runs linting and formatting as parallel jobs and improves the github action security by pinning dependencies.
It also fixes the ruff formatting errors.