### PR TITLE
Migrate identifier to correct format (str,str)

### DIFF
--- a/custom_components/victorsmartkill/entity.py
+++ b/custom_components/victorsmartkill/entity.py
@@ -80,7 +80,7 @@ class VictorSmartKillEntity(
         """Return device specific attributes."""
         # See: https://developers.home-assistant.io/docs/device_registry_index/#device-properties
         return DeviceInfo(
-            identifiers={(DOMAIN, self.trap.id, self.trap.serial_number)},
+            identifiers={(DOMAIN, f"IDSN:{self.trap.id}:{self.trap.serial_number}")},
             name=self.trap.name,
             model=self.trap.trap_type_verbose,
             manufacturer=MANUFACTURER,


### PR DESCRIPTION
Device identifiers should be a tuple (str,str). Current identifiers are (str,int,str) where the int is trap id and the last str is serial numer, and should be migrated to correct format. The second str should be "IDSN:<trap id>:<serial number>":
- use IDSN as a prefix for this format to be identified later if needed
- use trap id as part of string
- use serial number as part of string 