### PR TITLE
Add serial_number to device registry

### DIFF
--- a/custom_components/victorsmartkill/entity.py
+++ b/custom_components/victorsmartkill/entity.py
@@ -86,6 +86,7 @@ class VictorSmartKillEntity(
             manufacturer=MANUFACTURER,
             sw_version=self.trap.trapstatistics.firmware_version,
             hw_version=self.trap.trapstatistics.board_type,
+            serial_number=self.trap.serial_number,
         )
 
     @property


### PR DESCRIPTION
Serial number is now available to be set on device registry entries, and trap.serial_number can be used.