### PR TITLE
Use hass ssl context

### DIFF
--- a/custom_components/victorsmartkill/__init__.py
+++ b/custom_components/victorsmartkill/__init__.py
@@ -6,11 +6,7 @@ import dataclasses as dc
 import datetime as dt
 import logging
 from typing import TYPE_CHECKING, Any
-from homeassistant.util.ssl import (
-    SSLCipherList,
-    client_context,
-    create_no_verify_ssl_context,
-)
+
 import victor_smart_kill as victor
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -23,6 +19,7 @@ from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util.ssl import client_context
 
 from custom_components.victorsmartkill.const import (
     DEFAULT_UPDATE_INTERVAL_MINUTES,

--- a/custom_components/victorsmartkill/__init__.py
+++ b/custom_components/victorsmartkill/__init__.py
@@ -6,7 +6,11 @@ import dataclasses as dc
 import datetime as dt
 import logging
 from typing import TYPE_CHECKING, Any
-
+from homeassistant.util.ssl import (
+    SSLCipherList,
+    client_context,
+    create_no_verify_ssl_context,
+)
 import victor_smart_kill as victor
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -105,7 +109,9 @@ class VictorSmartKillDataUpdateCoordinator(DataUpdateCoordinator[list[victor.Tra
     ) -> None:
         """Initialize."""
         self.platforms: list[Platform] = platforms
-        self._client = victor.VictorAsyncClient(username, password)
+        self._client = victor.VictorAsyncClient(
+            username, password, verify=client_context()
+        )
         self._api = victor.VictorApi(self._client)
         self._close = False
 


### PR DESCRIPTION
Use HASS ssl context to avoid blocking operations. See https://developers.home-assistant.io/docs/asyncio_blocking_operations/#load_default_certs